### PR TITLE
#8 Support gulp build --watch=0

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,4 +1,5 @@
 <!-- TODO: Temporary until a server is created -->
+<!doctype html>
 <html>
     <head>
       <title>React Boilerplate</title>

--- a/tasks/build/build.js
+++ b/tasks/build/build.js
@@ -4,11 +4,10 @@ var gulp = require('gulp');
 var gutil = require('gulp-util');
 var del = require('del');
 var webpack = require('webpack');
-var args = require('yargs')
-    .default('watch', false)
-    .argv;
+var args = require('yargs').argv;
 
-args.watch = args.watch === true ? 300 : args.watch;
+var watch = 'watch' in args;
+var watchTimeout = typeof args.watch === 'number' ? args.watch : 300;
 
 /**
  * Deletes the contents of the dist directory.
@@ -45,20 +44,20 @@ function build(done) {
         }));
         done();
 
-        if (args.watch) {
+        if (watch) {
             gutil.log(gutil.colors.cyan('Watching for changes with a ' +
-                args.watch + 'ms timeout.'));
+                watchTimeout + 'ms timeout.'));
         }
     }
 
-    if (args.watch) {
-        watcher = compiler.watch(args.watch, webpackCallback);
+    if (watch) {
+        watcher = compiler.watch(watchTimeout, webpackCallback);
     } else {
         compiler.run(webpackCallback);
     }
 
     process.on('SIGINT', function() {
-        if (args.watch) {
+        if (watch) {
             watcher.close(function() {
                 gutil.log(gutil.colors.red('Stopped watching.'));
             });


### PR DESCRIPTION
I decided not to bother handling gulp build --watch=false as false comes through as a string so we'd have to coerce it etc. and it's really not a necessary cmd.

Try:
gulp build // expect watch === false, watchTimeout === 300
gulp build --watch // expect watch === true, watchTimeout === 300
gulp build --watch=10 // expect watch === true, watchTimeout === 10
gulp build --watch=0 // expect watch === true, watchTimeout === 0
