### PR TITLE
Add gulp editorconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
-node_modules
+.editorconfig
 dist
+node_modules

--- a/README.md
+++ b/README.md
@@ -3,5 +3,7 @@
 - `npm install -g git+ssh://git@github.com:gulpjs/gulp.git#4.0`
 - `npm install`
 - `gulp --tasks-simple`
+- `gulp lint`
+- `gulp editorconfig`
 - `gulp build`
 - `gulp build --release --watch` (watch can also be a number to set Webpacks aggregateTimeout)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,8 @@
 
 // Default args used by two or more tasks.
 require('yargs')
-    .default('release', false);
+    .default('env', 'dev');
 
 require('./tasks/lint');
+require('./tasks/editorconfig');
 require('./tasks/build/build');

--- a/tasks/editorconfig.js
+++ b/tasks/editorconfig.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var gulp = require('gulp');
+
+/**
+ * Copies `.editorconfig` from the 'coding-standards' module.
+ * @return {Stream} File stream.
+ */
+function copy() {
+    return gulp.src('node_modules/coding-standards/.editorconfig')
+        .pipe(gulp.dest(''));
+}
+
+gulp.task('editorconfig', copy);


### PR DESCRIPTION
Running `gulp editorconfig` will copy the .editorconfig file from our coding standards repo, not as elegant as extending the .eslint files but still ensures we can push changes out to all projects.
