### PR TITLE
Add CSS reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "andlog": "git+ssh://git@github.com:60frames/andlog.git#v1.0.1",
     "colors": "^1.1.2",
     "compression": "^1.5.1",
+    "css-reset": "git+ssh://git@github.com:60frames/css-reset.git#1.0.0",
     "debug": "^2.2.0",
     "dotenv": "^1.2.0",
     "express": "^4.13.1",

--- a/src/components/layout/layout.css
+++ b/src/components/layout/layout.css
@@ -4,14 +4,10 @@
 
 .navSet {
     composes: clearfix from 'assets/css/clearfix.css';
-    /* TODO: Include reset CSS and load it globally */
-    padding: 0;
     margin: 0 0 10px 0;
 }
 
 .navItem {
-    /* TODO: Include reset CSS and load it globally */
-    list-style: none;
     float: left;
     margin-right: 10px;
 }

--- a/src/entry.js
+++ b/src/entry.js
@@ -1,3 +1,4 @@
+import 'css-reset';
 import logger from 'andlog';
 import React from 'react';
 import Router from 'react-router';

--- a/tasks/build/webpack.config.js
+++ b/tasks/build/webpack.config.js
@@ -43,17 +43,28 @@ defaultConfig = {
             // Loaders are usually an array but instead we are using
             // an object so we can override easily in other Webpack
             // configurations.
-            extract: {
+            localCss: {
                 test: /\.css$/,
+                exclude: /node_modules/,
                 loader: ExtractTextPlugin.extract(
                     'style',
                     'css?modules&localIdentName=[name]-[local]_[hash:base64:5]!autoprefixer'
                 )
             },
+            // We make the assumption that all CSS in node_modules is either
+            // regular 'global' css or pre-compiled.
+            globalCss: {
+                test: /\.css$/,
+                include: /node_modules/,
+                loader: ExtractTextPlugin.extract(
+                    'style',
+                    'css'
+                )
+            },
             fileLoader: {
                 test: /\.(jpe?g|png|gif|svg|woff|ttf|eot)$/i,
                 // Files under 10kb will become a DataUrl.
-                // Anything more then this should probabaly be downloaded and
+                // Anything more then this should probably be downloaded and
                 // cached as its own file.
                 loader: 'url?limit=10000'
             },

--- a/tasks/build/webpack.release.config.js
+++ b/tasks/build/webpack.release.config.js
@@ -17,7 +17,7 @@ config.defaultConfig.plugins.define = new webpack.DefinePlugin({
     }
 });
 
-config.defaultConfig.module.loaders.extract.loader = ExtractTextPlugin.extract(
+config.defaultConfig.module.loaders.localCss.loader = ExtractTextPlugin.extract(
     'style',
     'css?modules&localIdentName=[hash:base64:5]!autoprefixer'
 );


### PR DESCRIPTION
All CSS in node_modules is now compiled as global CSS, i.e. doesn't use CSS modules.

We might later want to consider a more flexible way to opt in / out of global / local css, maybe by file naming convention, e.g. `reset.global.css` but for now I think it's worth trying out the assumption that all css in node_modules is global.
