### PR TITLE
Try using webpack hmr api on server instead of webpack-hot-server-middleware

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -14,7 +14,9 @@ app.use(compression());
 app.use('/api', api);
 
 if (process.env.WEBPACK_DEV_SERVER === 'true') {
-    app.use(require('./routes/webpack'));
+    const middleware = require('../dist/serverrouter').default;
+    app.use(middleware);
+    // app.use(require('../routes/webpack'));
 } else {
     app.use(require('./routes/static'));
 }

--- a/src/server.js
+++ b/src/server.js
@@ -54,8 +54,8 @@ function getCssFromStats(stats) {
 }
 
 function render(stats, renderProps, store) {
-    const js = getJsFromStats(stats);
-    const css = getCssFromStats(stats);
+    const js = ''; // getJsFromStats(stats);
+    const css = ''; // getCssFromStats(stats);
 
     const markup = renderToString(
         <Provider store={store}>

--- a/src/serverrouter.js
+++ b/src/serverrouter.js
@@ -1,0 +1,17 @@
+import express from 'express';
+import serverRenderer from './server'
+
+const router = express.Router();
+let middleware = serverRenderer;
+
+router.use((req, res, next) => {
+    middleware()(req, res, next);
+});
+
+if (module.hot) {
+    module.hot.accept('./server', () => {
+        middleware = require('./server').default;
+    });
+}
+
+export default router;

--- a/tasks/build/generateConfig.js
+++ b/tasks/build/generateConfig.js
@@ -76,8 +76,12 @@ module.exports = function generateConfig(options) {
     }
 
     if (options.hot) {
-        config.entry[options.name].unshift('webpack-hot-middleware/client');
-        config.entry[options.name].unshift('react-hot-loader/patch');
+        if (options.node) {
+            config.entry[options.name].unshift('webpack/hot/poll?1000');
+        } else {
+            config.entry[options.name].unshift('webpack-hot-middleware/client');
+            config.entry[options.name].unshift('react-hot-loader/patch');
+        }
     }
 
     return config;

--- a/tasks/build/index.js
+++ b/tasks/build/index.js
@@ -5,7 +5,7 @@ const async = require('async');
 const fs = require('fs-extra');
 const webpack = require('webpack');
 const ProgressBarWebpackPlugin = require('progress-bar-webpack-plugin');
-const config = require('./webpack.release.config');
+const config = require('./webpack.config');
 
 const SRC_DIR = config[0].context;
 const DIST_DIR = config[0].output.path;

--- a/tasks/build/webpack.config.js
+++ b/tasks/build/webpack.config.js
@@ -17,9 +17,10 @@ module.exports = [
         publicPath: 'http://localhost:6060/'
     }),
     generateConfig({
-        name: 'server',
+        name: 'serverrouter',
         debug: true,
         node: true,
-        sourceMaps: 'eval'
+        sourceMaps: 'eval',
+        hot: true
     })
 ];


### PR DESCRIPTION
TODO:
- Hook up client side assets.
- Use in-memory compilation from webpack-dev-server (although actually it looks although 'webpack/hot/poll' is only capable of reading from the file system as it uses node `require` to fetch the hot update manifest and chunks).
- Pass client stats to serverRenderer middleware.

Observations
- Given this will need to `require()` the server bundle from the memory fs to perform the initial mount anyway it doesn't really seem worth going through the Webpack HMR api to switch the server renderer middleware to the latest compilation when it can just be switched on each compilation (i.e. exactly how webpack-hot-server-middleware does).
