### PR TITLE
Use location instead of the undefined query property

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -31,12 +31,12 @@ function fetchComponentData(renderProps, store) {
       component = component.WrappedComponent;
     }
     if (component.fetchData) {
-      const { query, params, history } = renderProps;
+      const { location, params, history } = renderProps;
       return (
         component
           .fetchData({
             dispatch: store.dispatch,
-            query,
+            query: location.query,
             params,
             history
           })


### PR DESCRIPTION
Hi @richardscarrott,

I've found something which I consider a minor bug in your boilerplate. In the `fetchComponentData`in the `server.js` you are destructuring the `renderProps` into `query`, `params` and `history`. But `query` is undefined. If I want to access the query parameters, I first have to get the `location` property and then access the `query`.